### PR TITLE
Slider for spectacle page works.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/BACK/strapi-sens-interdits/api/spectacle/models/spectacle.settings.json
+++ b/BACK/strapi-sens-interdits/api/spectacle/models/spectacle.settings.json
@@ -23,13 +23,15 @@
     "subtitle": {
       "type": "string"
     },
-    "content": {
-      "type": "richtext"
-    },
     "tab_element": {
       "type": "component",
       "repeatable": true,
       "component": "menu.tab-element"
+    },
+    "carousel": {
+      "type": "component",
+      "repeatable": false,
+      "component": "menu.medias-slider"
     }
   }
 }

--- a/FRONT/gatsby-sens-interdits/package-lock.json
+++ b/FRONT/gatsby-sens-interdits/package-lock.json
@@ -2765,9 +2765,9 @@
       "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q=="
     },
     "axios": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -3900,6 +3900,11 @@
           }
         }
       }
+    },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -7099,6 +7104,14 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "axios": {
+          "version": "0.20.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+          "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
         },
         "cross-spawn": {
           "version": "7.0.3",
@@ -12711,6 +12724,14 @@
         }
       }
     },
+    "react-easy-swipe": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
+      "integrity": "sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-error-overlay": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-3.0.0.tgz",
@@ -12820,6 +12841,16 @@
       "requires": {
         "react-style-singleton": "^2.1.0",
         "tslib": "^1.0.0"
+      }
+    },
+    "react-responsive-carousel": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.10.tgz",
+      "integrity": "sha512-O8MV2LoR07BttvWaXesyWkE6s8xRW6p6HiMkelZ3TuPYQwKnlw+fYtZN+bQ3/1jg0D5JQGATY4Hnw/4WEXHnag==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.5.8",
+        "react-easy-swipe": "^0.0.21"
       }
     },
     "react-style-singleton": {

--- a/FRONT/gatsby-sens-interdits/package.json
+++ b/FRONT/gatsby-sens-interdits/package.json
@@ -14,9 +14,11 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "dependencies": {
+    "axios": "^0.21.0",
     "gatsby": "^2.24.79",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "react-responsive-carousel": "^3.2.10"
   },
   "devDependencies": {
     "prettier": "2.1.2"

--- a/FRONT/gatsby-sens-interdits/src/components/globalscomponents/Carousel/ImageCarousel.css
+++ b/FRONT/gatsby-sens-interdits/src/components/globalscomponents/Carousel/ImageCarousel.css
@@ -1,0 +1,59 @@
+div.carousel-loading {
+  width: 100%;
+  height: 450px;
+  overflow: hidden;
+}
+
+div.carousel-loading img {
+  width: 100%;
+  transform: translate(0, -25%);
+}
+
+div.size-adjustment {
+  width: auto;
+  max-height: 450px;
+}
+
+div.size-adjustment img {
+  transform: translate(0, -25%);
+}
+
+div.red {
+  position: absolute;
+  top: 300px;
+  left: calc(50vw - 225px);
+  z-index: 1;
+  align-self: center;
+  background-color: rgb(255, 0, 0);
+  mix-blend-mode: multiply;
+  width: 450px;
+  height: 150px;
+}
+
+div.image-text {
+  position: absolute;
+  z-index: 1;
+  top: 330px;
+  left: calc(50vw - 225px);
+  width: 450px;
+  text-align: center;
+  align-self: center;
+  position: absolute;
+}
+
+div.image-text p {
+  color: #fff;
+  font-size: 26px;
+  font-weight: 600;
+  padding-bottom: 20px;
+}
+
+div.image-text button {
+  color: white;
+  font-size: 20px;
+  background-color: transparent;
+  padding: 5px;
+  border: 1px dotted #fff;
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+}

--- a/FRONT/gatsby-sens-interdits/src/components/globalscomponents/Carousel/ImageCarousel.js
+++ b/FRONT/gatsby-sens-interdits/src/components/globalscomponents/Carousel/ImageCarousel.js
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from "react"
+import "./ImageCarousel.css"
+import axios from "axios"
+import "react-responsive-carousel/lib/styles/carousel.min.css"
+import { Carousel } from "react-responsive-carousel"
+import placeholder from "../../../img/placeholder-photo-slider.jpg"
+
+function ImageCarousel() {
+  const [isLoading, setIsLoading] = useState(true)
+  const [images, setImages] = useState([])
+  const [spectacleTitle, setSpectacleTitle] = useState("")
+
+  function AxiosCall(url, dataTreatment) {
+    axios
+      .get(url)
+      .then(response => response.data)
+      .then(data => dataTreatment(data))
+  }
+
+  function dataImageTreatment(data) {
+    setSpectacleTitle(data[0].title)
+    setImages(data[0].carousel.image)
+    setIsLoading(false)
+  }
+
+  const urlSpectacles = "http://localhost:1337/spectacles"
+
+  useEffect(() => {
+    AxiosCall(urlSpectacles, dataImageTreatment)
+  }, [])
+
+  return isLoading ? (
+    <>
+      <div className="red"></div>
+      <div class="image-text">
+        <p>Contenu en cours de chargement</p>
+      </div>
+      <div className="carousel-loading">
+        <img src={placeholder} alt="placeholder_photo" />
+      </div>
+    </>
+  ) : (
+    <>
+      <div className="red"></div>
+      <div class="image-text">
+        <p>{spectacleTitle}</p>
+        <button>Réserver</button>
+      </div>
+      <Carousel
+        autoPlay={true}
+        infiniteLoop={true}
+        interval={5000}
+        showThumbs={false}
+        showStatus={false}
+        showIndicators={false}
+      >
+        {images.map(image => (
+          <div className="size-adjustment">
+            <img
+              src={"http://localhost:1337" + image.image.url}
+              alt={image.image.name}
+            />
+          </div>
+        ))}
+      </Carousel>
+    </>
+  )
+}
+
+export default ImageCarousel

--- a/FRONT/gatsby-sens-interdits/src/pages/spectacle.js
+++ b/FRONT/gatsby-sens-interdits/src/pages/spectacle.js
@@ -1,13 +1,13 @@
 import React from "react"
-import TabSystemH from "../components/globalscomponents/TabSystems/TabSystemH";
+import ImageCarousel from "../components/globalscomponents/Carousel/ImageCarousel"
+import TabSystemH from "../components/globalscomponents/TabSystems/TabSystemH"
 const Spectacle = () => {
   return (
-      <div>
-        <h1>This is the Spectacle page</h1>
-        <TabSystemH/>
-      </div>
-
+    <div>
+      <ImageCarousel />
+      <TabSystemH />
+    </div>
   )
 }
 
-export default Spectacle;
+export default Spectacle


### PR DESCRIPTION
For this one, I used an npm library called [react-responsive-carousel](https://www.npmjs.com/package/react-responsive-carousel). It has autoplay (we can change the speed for transition), it's super easy to use and the arrows are customizable. You'll need to "npm install" to try it out".
![](https://i.imgur.com/e2CrH1v.jpg)
![](https://i.imgur.com/GhXTvMk.jpg)

For the code itself, I put a **450px height for the slider** (easily changeable). 

I also **separated the axios function from the rest**, so in terms, it should be a Context Component that we could use for every API call. **It takes two parameters: url**, which is the route for the content we want to display, and **dataTreatment**, which is a function that does something with the data.

In this example, **url is "http://localhost:1337/spectacles"** (for now, because as soon as we have the festival/archive page this url will have the id of the spectacle as a param) and **dataTreatment is the function dataImageTreatment** that sets the images to display, the loader to false and the spectacle title that will be displayed on the red div.

