### PR TITLE
Changed the ImageCarousel so that images are not cut on top

### DIFF
--- a/FRONT/gatsby-sens-interdits/src/components/globals/Carousel/ImageCarousel.css
+++ b/FRONT/gatsby-sens-interdits/src/components/globals/Carousel/ImageCarousel.css
@@ -14,10 +14,6 @@ div.size-adjustment {
   max-height: calc(100vh - 280px); /*450px*/
 }
 
-div.size-adjustment img {
-  transform: translate(0, -25%);
-}
-
 div.carousel-wrapper {
   position: relative;
   display: flex;


### PR DESCRIPTION
I just changed a line in the CSS so that the carousel displays photo with the top border glued to the bottom of the header.