### PR TITLE
Added cookies to LanguageContext

### DIFF
--- a/FRONT/gatsby-sens-interdits/package-lock.json
+++ b/FRONT/gatsby-sens-interdits/package-lock.json
@@ -1739,6 +1739,11 @@
       "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-2.1.1.tgz",
       "integrity": "sha1-zR6FU2M60xhcPy8jns/10mQ+krY="
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "@types/debug": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
@@ -1772,6 +1777,15 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
       "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA=="
+    },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
     },
     "@types/http-proxy": {
       "version": "1.17.4",
@@ -12489,6 +12503,16 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-cookie": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.0.3.tgz",
+      "integrity": "sha512-cmi6IpdVgTSvjqssqIEvo779Gfqc4uPGHRrKMEdHcqkmGtPmxolGfsyKj95bhdLEKqMdbX8MLBCwezlnhkHK0g==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-dev-utils": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-4.2.3.tgz",
@@ -15257,6 +15281,15 @@
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^4.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
       }
     },
     "universalify": {

--- a/FRONT/gatsby-sens-interdits/package.json
+++ b/FRONT/gatsby-sens-interdits/package.json
@@ -20,6 +20,7 @@
     "gatsby": "^2.24.79",
     "gatsby-source-strapi": "0.0.12",
     "react": "^16.12.0",
+    "react-cookie": "^4.0.3",
     "react-dom": "^16.12.0",
     "react-markdown": "^5.0.3",
     "react-responsive-carousel": "^3.2.10",

--- a/FRONT/gatsby-sens-interdits/src/components/context/LanguageProvider.js
+++ b/FRONT/gatsby-sens-interdits/src/components/context/LanguageProvider.js
@@ -1,11 +1,22 @@
 import React, { useState, useEffect } from "react";
 import LanguageContext from "./LanguageContext";
+import { useCookies } from "react-cookie";
 
 export default props => {
+  const [hasMounted, setHasMounted] = useState(false);
   const [language, setLanguage] = useState("fr");
   const [LANG, setLANG] = useState("");
+  const [cookies, setCookie, removeCookie] = useCookies(["language"]);
 
   useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  useEffect(() => {
+    setCookie("language", language, "sameSite=true");
+    if (!hasMounted) {
+      setLanguage(cookies.language);
+    }
     language === "en" ? setLANG("_en") : setLANG("");
   }, [language]);
 


### PR DESCRIPTION
I finally added the cookie to the translation so that not only you don't have to choose your language with each page, but the the choice stay when you close your tab/browser.

This PR adds a **new dependency** too: react-cookie! So **npm install** when it's merged.